### PR TITLE
Update Customizer font size title #258

### DIFF
--- a/inc/customizer/class-visualcomposerstarter-customizer.php
+++ b/inc/customizer/class-visualcomposerstarter-customizer.php
@@ -1441,7 +1441,7 @@ class VisualComposerStarter_Customizer {
 			),
 		) );
 		$wp_customize->add_control( 'vct_fonts_and_style_h1_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h1',
 			'settings'   => 'vct_fonts_and_style_h1_font_size',
 			'type'    => 'text',
@@ -1610,7 +1610,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_h2_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h2',
 			'settings'   => 'vct_fonts_and_style_h2_font_size',
 			'type'    => 'text',
@@ -1772,7 +1772,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_h3_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h3',
 			'settings'   => 'vct_fonts_and_style_h3_font_size',
 			'type'    => 'text',
@@ -1941,7 +1941,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_h4_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h4',
 			'settings'   => 'vct_fonts_and_style_h4_font_size',
 			'type'    => 'text',
@@ -2109,7 +2109,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_h5_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h5',
 			'settings'   => 'vct_fonts_and_style_h5_font_size',
 			'type'    => 'text',
@@ -2278,7 +2278,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_h6_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_h6',
 			'settings'   => 'vct_fonts_and_style_h6_font_size',
 			'type'    => 'text',
@@ -2470,7 +2470,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_body_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_body',
 			'settings'   => 'vct_fonts_and_style_body_font_size',
 			'type'    => 'text',
@@ -2672,7 +2672,7 @@ class VisualComposerStarter_Customizer {
 		) );
 
 		$wp_customize->add_control( 'vct_fonts_and_style_buttons_font_size', array(
-			'label'   => esc_html__( 'Size', 'visual-composer-starter' ),
+			'label'   => esc_html__( 'Size (include px, pt, etc.)', 'visual-composer-starter' ),
 			'section' => 'vct_fonts_and_style_buttons',
 			'settings'   => 'vct_fonts_and_style_buttons_font_size',
 			'type'    => 'text',


### PR DESCRIPTION
In Fonts & Style section of theme Customiser replaced the **Size** field title to  **Size (include px, pt, etc.)**