### PR TITLE
Fix "Add to Cart" button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -436,7 +436,7 @@ if ( ! function_exists( 'visualcomposerstarter_script' ) ) {
 		/* Main theme JS functions */
 		wp_register_script( 'visualcomposerstarter-script', get_template_directory_uri() . '/js/functions.min.js', array( 'jquery-core' ), VISUALCOMPOSERSTARTER_VERSION, true );
 
-		wp_localize_script( 'bootstrap-transition', 'visualcomposerstarter', array(
+		wp_localize_script( 'visualcomposerstarter-script', 'visualcomposerstarter', array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
 			'nonce' => wp_create_nonce( 'visualcomposerstarter' ),
 			'woo_coupon_form' => get_theme_mod( 'woocommerce_coupon_from', false ),


### PR DESCRIPTION
The error was caused by the missing `window.visualcomposerstarter` object on the page.